### PR TITLE
Added `skip` and `limit` to document array to simulate paginated results

### DIFF
--- a/lib/sinon-mongo.js
+++ b/lib/sinon-mongo.js
@@ -50,6 +50,8 @@ const install = sinon => {
     if (result.constructor !== Array) result = [result];
 
     return {
+      limit: sinon.stub().returnsThis(),
+      skip: sinon.stub().returnsThis(),
       sort: sinon.stub().returnsThis(),
       toArray: () => Promise.resolve(result)
     };

--- a/test/unit/sinon-mongo.test.js
+++ b/test/unit/sinon-mongo.test.js
@@ -310,6 +310,27 @@ describe('sinon-mongo', () => {
       });
     });
 
+    describe('that uses skip() and limit()', () => {
+      it('can use the documentArray to mimic paginated results using skip and limit', () => {
+        const data = [{the: 'first mock document'}, {the: 'second mock document'}];
+        const mockCollection = {
+          find: sinon.stub()
+            .withArgs({name: 'foo'}, {email: 1, name: 1})
+            .returns(sinon.mongo.documentArray(data))
+        };
+
+        return mockCollection.find({name: 'foo'}, {email: 1, name: 1})
+          .skip(1)
+          .limit(1)
+          .toArray()
+
+          .then(result => {
+            expect(result).to.have.lengthOf(2);
+            expect(result).to.be.eql([{the: 'first mock document'}, {the: 'second mock document'}]);
+          })
+      });
+    });
+
     describe('that return streams', () => {
       const functionUsingCollection = collection => {
         return collection


### PR DESCRIPTION
Added stubs for the `skip` and `limit` functions so that the library can be used to model paginated queries.